### PR TITLE
Fix Player Position Bug

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -6,6 +6,10 @@ class Camera:
         self.x, self.y = 0, 0
         self.look_at(*start_pos or (0,0))
 
+    @property
+    def offset(self):
+        return -self.x, -self.y
+
     def move(self, x_offset, y_offset):
         self.x += x_offset
         self.y += y_offset

--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ def main():
 
     tilemap = Tilemap()
 
+    print(tilemap.player_pos)
+
     player = Player(
         (tilemap.player_pos[0], tilemap.player_pos[1], 20, 50),
         c.PHYS_WALK_SPEED,
@@ -49,7 +51,7 @@ def main():
         camera.look_at_centered(*player.Center)
 
         screen.fill((144, 244, 200))
-        tilemap.draw(screen, player, camera.world_to_screen_rect)
+        tilemap.draw(screen, player, camera)
         #player.draw(screen, camera.world_to_screen_rect)
 
 

--- a/player.py
+++ b/player.py
@@ -58,6 +58,9 @@ class Player(Entity):
     def set_collisionmap(self, collision_map):
         self.collision_map = collision_map
 
+    def draw(self, surface, camera):
+        pg.draw.rect(surface, 0xff00ff, camera.world_to_screen_rect(self.Rect), 2)
+
     def handle_event(self, event):
         if event.type == pg.KEYDOWN:
             self.vel_x += (event.key == pg.K_d) - (event.key == pg.K_a)

--- a/tilemap.py
+++ b/tilemap.py
@@ -56,11 +56,14 @@ class Tilemap:
         self.rects.clear()
         self.rects.extend(rects)
 
-    def draw(self, surface, player, world_to_screen_rect):
+    def draw(self, surface, player, camera):
         # for rect in self.rects:
         #     pg.draw.rect(surface, (0, 0, 0), world_to_screen_rect(rect))
-        surface.blit(self.layerBackground, (0, 0))
-        pg.draw.rect(surface, 0x00ff00, world_to_screen_rect(player.Rect), 2)
-        surface.blit(self.layerTiles, (0, 0))
-        surface.blit(self.layerTrees, (0, 0))
-        surface.blit(self.layerAssets, (0, 0))
+        
+        surface.blit(self.layerBackground, camera.offset)
+        
+        player.draw(surface, camera)
+        
+        surface.blit(self.layerTiles, camera.offset)
+        surface.blit(self.layerTrees, camera.offset)
+        surface.blit(self.layerAssets, camera.offset)


### PR DESCRIPTION
Fixed the bug where the player appeared to be in the wrong position.

The world was being rendered at (0,0) without the camera offset being applied.

A new property for camera has been added called Offset which can be used to get how far an object should be offset from its original position.  The value from this property is used for the position of the world images.

The player rendering has been moved to the player class and is called by the Tilemap draw method rather than being drawn directly by the Tilemap.